### PR TITLE
feat(multiple-hosted-zones): the zones variable was added to support multiple hosted zones

### DIFF
--- a/examples/acm-multiple-hosted-zones/main.tf
+++ b/examples/acm-multiple-hosted-zones/main.tf
@@ -1,0 +1,79 @@
+locals {
+  # Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)
+  use_existing_route53_zone = var.use_existing_route53_zone
+
+  domain       = var.domain
+  extra_domain = var.extra_domain
+
+  # Removing trailing dot from domain - just to be sure :)
+  domain_name = trimsuffix(local.domain, ".")
+
+  region = "us-east-1"
+
+  zone_id = try(data.aws_route53_zone.this[0].zone_id, aws_route53_zone.this[0].zone_id)
+}
+
+##########################################################
+# Example (use multiple domains in the same certificate):
+# Generate an ACM certificate for multiple domains, useful
+# to be used in CloudFront which only supports one ACM
+# certificate.
+##########################################################
+
+# REF: https://github.com/terraform-aws-modules/terraform-aws-acm/pull/137
+
+provider "aws" {
+  region = local.region
+}
+
+data "aws_route53_zone" "this" {
+  count = local.use_existing_route53_zone ? 1 : 0
+
+  name         = local.domain_name
+  private_zone = false
+}
+
+resource "aws_route53_zone" "this" {
+  count = !local.use_existing_route53_zone ? 1 : 0
+
+  name = local.domain_name
+}
+
+data "aws_route53_zone" "extra" {
+  count = local.use_existing_route53_zone ? 1 : 0
+
+  name         = local.extra_domain
+  private_zone = false
+}
+
+resource "aws_route53_zone" "extra" {
+  count = !local.use_existing_route53_zone ? 1 : 0
+
+  name = local.extra_domain
+}
+
+module "acm_multi_domain" {
+  source = "../../modules/acm/"
+
+  domain_name = local.domain_name
+  zone_id     = local.zone_id
+
+  subject_alternative_names = [
+    "*.alerts.${local.domain_name}",
+    "new.sub.${local.domain_name}",
+    "*.${local.domain_name}",
+    "alerts.${local.domain_name}",
+    "*.alerts.${local.extra_domain}",
+    "new.sub.${local.extra_domain}",
+    "*.${local.extra_domain}",
+    "alerts.${local.extra_domain}",
+    local.extra_domain,
+    "*.${local.extra_domain}"
+  ]
+
+  zones = {
+    (local.extra_domain)            = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
+    "alerts.${local.extra_domain}"  = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
+    "new.sub.${local.extra_domain}" = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id)
+  }
+}

--- a/examples/acm-multiple-hosted-zones/main.tf
+++ b/examples/acm-multiple-hosted-zones/main.tf
@@ -1,78 +1,76 @@
-locals {
-  # Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)
-  use_existing_route53_zone = var.use_existing_route53_zone
-
-  domain       = var.domain
-  extra_domain = var.extra_domain
-
-  # Removing trailing dot from domain - just to be sure :)
-  domain_name = trimsuffix(local.domain, ".")
-
-  region = "us-east-1"
-
-  zone_id = try(data.aws_route53_zone.this[0].zone_id, aws_route53_zone.this[0].zone_id)
-}
-
-##########################################################
+# ---------------------------------------------------------------------------------------------------------------------
 # Example (use multiple domains in the same certificate):
 # Generate an ACM certificate for multiple domains, useful
 # to be used in CloudFront which only supports one ACM
 # certificate.
-##########################################################
+# ---------------------------------------------------------------------------------------------------------------------
 
 # REF: https://github.com/terraform-aws-modules/terraform-aws-acm/pull/137
 
+locals {
+  zone_id = try(data.aws_route53_zone.this[0].zone_id, aws_route53_zone.this[0].zone_id)
+}
+
 provider "aws" {
-  region = local.region
+  region = var.aws_region
 }
 
+# If you already have the hosted zones, they can be used to test this example.
+# Just set the use_existing_route53_zone variable as true and configure the 
+# domain_name and extra_domain variables with the correspond values.
 data "aws_route53_zone" "this" {
-  count = local.use_existing_route53_zone ? 1 : 0
+  count = var.use_existing_route53_zone ? 1 : 0
 
-  name         = local.domain_name
+  name         = var.domain_name
   private_zone = false
-}
-
-resource "aws_route53_zone" "this" {
-  count = !local.use_existing_route53_zone ? 1 : 0
-
-  name = local.domain_name
 }
 
 data "aws_route53_zone" "extra" {
-  count = local.use_existing_route53_zone ? 1 : 0
+  count = var.use_existing_route53_zone ? 1 : 0
 
-  name         = local.extra_domain
+  name         = var.extra_domain
   private_zone = false
 }
 
-resource "aws_route53_zone" "extra" {
-  count = !local.use_existing_route53_zone ? 1 : 0
+# If you need to deploy also the hosted zones for test the example, then
+# set the use_existing_route53_zone variable as false. This way, the example will 
+# create both hosted zones, using the domain_name and extra_domain values.
+resource "aws_route53_zone" "this" {
+  count = !var.use_existing_route53_zone ? 1 : 0
 
-  name = local.extra_domain
+  name = var.domain_name
+}
+
+resource "aws_route53_zone" "extra" {
+  count = !var.use_existing_route53_zone ? 1 : 0
+
+  name = var.extra_domain
 }
 
 module "acm_multi_domain" {
   source = "../../modules/acm/"
 
-  domain_name = local.domain_name
+  domain_name = var.domain_name
   zone_id     = local.zone_id
 
   subject_alternative_names = [
-    "*.alerts.${local.domain_name}",
-    "new.sub.${local.domain_name}",
-    "*.${local.domain_name}",
-    "alerts.${local.domain_name}",
-    "*.alerts.${local.extra_domain}",
-    "new.sub.${local.extra_domain}",
-    "*.${local.extra_domain}",
-    "alerts.${local.extra_domain}",
-    local.extra_domain,
-    "*.${local.extra_domain}"
+    "*.alerts.${var.domain_name}",
+    "new.sub.${var.domain_name}",
+    "*.${var.domain_name}",
+    "alerts.${var.domain_name}",
+    "*.alerts.${var.extra_domain}",
+    "new.sub.${var.extra_domain}",
+    "*.${var.extra_domain}",
+    "alerts.${var.extra_domain}",
+    var.extra_domain,
+    "*.${var.extra_domain}"
   ]
 
+  # Each extra subdomain must be mapped to the correct zone id.
+  # If not, the module creates the records using the zone_id variable (not the
+  # extra domain zone id) and the validation will fail.
   zones = {
-    (local.extra_domain)            = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
+    (var.extra_domain)              = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
     "alerts.${local.extra_domain}"  = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
     "new.sub.${local.extra_domain}" = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id)
   }

--- a/examples/acm-multiple-hosted-zones/variables.tf
+++ b/examples/acm-multiple-hosted-zones/variables.tf
@@ -1,0 +1,17 @@
+variable "use_existing_route53_zone" {
+  description = "Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)"
+  type        = bool
+  default     = true
+}
+
+variable "domain" {
+  description = "Domain to be used for the tests"
+  type        = string
+  default     = "terraform-aws-modules.modules.tf"
+}
+
+variable "extra_domain" {
+  description = "Extr adomain to be used for the tests"
+  type        = string
+  default     = "extra.terraform-aws-modules.modules.tf"
+}

--- a/examples/acm-multiple-hosted-zones/variables.tf
+++ b/examples/acm-multiple-hosted-zones/variables.tf
@@ -4,7 +4,7 @@ variable "use_existing_route53_zone" {
   default     = true
 }
 
-variable "domain" {
+variable "domain_name" {
   description = "Domain to be used for the tests"
   type        = string
   default     = "terraform-aws-modules.modules.tf"
@@ -14,4 +14,10 @@ variable "extra_domain" {
   description = "Extr adomain to be used for the tests"
   type        = string
   default     = "extra.terraform-aws-modules.modules.tf"
+}
+
+variable "aws_region" {
+  description = "The AWS Region where this VPC will exist."
+  type        = string
+  default     = "us-east-1"
 }

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -54,7 +54,7 @@ resource "aws_acm_certificate" "this" {
 resource "aws_route53_record" "validation" {
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
-  zone_id = length(var.zone_id) == 1 ? var.zone_id[0] : element(var.zone_id, count.index)
+  zone_id = lookup(var.zones, element(local.validation_domains, count.index)["domain_name"], var.zone_id)
   name    = element(local.validation_domains, count.index)["resource_record_name"]
   type    = element(local.validation_domains, count.index)["resource_record_type"]
   ttl     = var.dns_ttl

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -54,7 +54,7 @@ resource "aws_acm_certificate" "this" {
 resource "aws_route53_record" "validation" {
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
-  zone_id = var.zone_id
+  zone_id = length(var.zone_id) == 1 ? var.zone_id[0] : element(var.zone_id, count.index)
   name    = element(local.validation_domains, count.index)["resource_record_name"]
   type    = element(local.validation_domains, count.index)["resource_record_type"]
   ttl     = var.dns_ttl
@@ -73,5 +73,5 @@ resource "aws_acm_certificate_validation" "this" {
 
   certificate_arn = aws_acm_certificate.this[0].arn
 
-  validation_record_fqdns = aws_route53_record.validation.*.fqdn
+  validation_record_fqdns = aws_route53_record.validation[*].fqdn
 }

--- a/modules/acm/outputs.tf
+++ b/modules/acm/outputs.tf
@@ -1,21 +1,21 @@
 output "acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value       = element(concat(aws_acm_certificate_validation.this.*.certificate_arn, aws_acm_certificate.this.*.arn, [""]), 0)
+  value       = element(concat(aws_acm_certificate_validation.this[*].certificate_arn, aws_acm_certificate.this[*].arn, [""]), 0)
 }
 
 output "acm_certificate_domain_validation_options" {
   description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
-  value       = flatten(aws_acm_certificate.this.*.domain_validation_options)
+  value       = flatten(aws_acm_certificate.this[*].domain_validation_options)
 }
 
 output "acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
-  value       = flatten(aws_acm_certificate.this.*.validation_emails)
+  value       = flatten(aws_acm_certificate.this[*].validation_emails)
 }
 
 output "validation_route53_record_fqdns" {
   description = "List of FQDNs built using the zone domain and name."
-  value       = aws_route53_record.validation.*.fqdn
+  value       = aws_route53_record.validation[*].fqdn
 }
 
 output "distinct_domain_names" {

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -28,28 +28,10 @@ variable "certificate_transparency_logging_preference" {
   default     = true
 }
 
-variable "domain_name" {
-  description = "A domain name for which the certificate should be issued"
-  type        = string
-  default     = ""
-}
-
-variable "subject_alternative_names" {
-  description = "A list of domains that should be SANs in the issued certificate"
-  type        = list(string)
-  default     = []
-}
-
 variable "validation_method" {
   description = "Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform."
   type        = string
   default     = "DNS"
-}
-
-variable "zone_id" {
-  description = "The ID of the hosted zone to contain this record."
-  type        = list(string)
-  default     = []
 }
 
 variable "tags" {
@@ -62,4 +44,28 @@ variable "dns_ttl" {
   description = "The TTL of DNS recursive resolvers to cache information about this record."
   type        = number
   default     = 60
+}
+
+variable "zone_id" {
+  description = "The ID of the hosted zone to contain this record. Required when validating via Route53"
+  type        = string
+  default     = ""
+}
+
+variable "zones" {
+  description = "Map containing the Route53 Zone IDs for additional domains."
+  type        = map(string)
+  default = {}
+}
+
+variable "domain_name" {
+  description = "A domain name for which the certificate should be issued"
+  type        = string
+  default     = ""
+}
+
+variable "subject_alternative_names" {
+  description = "A list of domains that should be SANs in the issued certificate"
+  type        = list(string)
+  default     = []
 }

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -37,7 +37,7 @@ variable "domain_name" {
 variable "subject_alternative_names" {
   description = "A list of domains that should be SANs in the issued certificate"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "validation_method" {
@@ -49,7 +49,7 @@ variable "validation_method" {
 variable "zone_id" {
   description = "The ID of the hosted zone to contain this record."
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "tags" {

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -31,13 +31,13 @@ variable "certificate_transparency_logging_preference" {
 variable "domain_name" {
   description = "A domain name for which the certificate should be issued"
   type        = string
-  default     = "*.cdi2.korodrogerie.de"
+  default     = ""
 }
 
 variable "subject_alternative_names" {
   description = "A list of domains that should be SANs in the issued certificate"
   type        = list(string)
-  default     = ["*.cdi2.koro-shop.com", "*.cdi2.koro.ie", "asd.cdi2.koro.ie"]
+  default     = [""]
 }
 
 variable "validation_method" {
@@ -49,7 +49,7 @@ variable "validation_method" {
 variable "zone_id" {
   description = "The ID of the hosted zone to contain this record."
   type        = list(string)
-  default     = ["Z09485142T3CCUITNRYHU", "Z01846543BNDDIV2KMEJV", "Z0828588372KK89WM5FAI", "Z0828588372KK89WM5FAI"]
+  default     = [""]
 }
 
 variable "tags" {

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -55,7 +55,7 @@ variable "zone_id" {
 variable "zones" {
   description = "Map containing the Route53 Zone IDs for additional domains."
   type        = map(string)
-  default = {}
+  default     = {}
 }
 
 variable "domain_name" {

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -31,13 +31,13 @@ variable "certificate_transparency_logging_preference" {
 variable "domain_name" {
   description = "A domain name for which the certificate should be issued"
   type        = string
-  default     = ""
+  default     = "*.cdi2.korodrogerie.de"
 }
 
 variable "subject_alternative_names" {
   description = "A list of domains that should be SANs in the issued certificate"
   type        = list(string)
-  default     = []
+  default     = ["*.cdi2.koro-shop.com", "*.cdi2.koro.ie", "asd.cdi2.koro.ie"]
 }
 
 variable "validation_method" {
@@ -48,8 +48,8 @@ variable "validation_method" {
 
 variable "zone_id" {
   description = "The ID of the hosted zone to contain this record."
-  type        = string
-  default     = ""
+  type        = list(string)
+  default     = ["Z09485142T3CCUITNRYHU", "Z01846543BNDDIV2KMEJV", "Z0828588372KK89WM5FAI", "Z0828588372KK89WM5FAI"]
 }
 
 variable "tags" {


### PR DESCRIPTION
# 🚀  Release Notes

## What's changed

### **New variable:**
**zones**:  Map containing the Route53 Zone IDs for additional domains.
 _Type_: map(string).

### Use case
This new variable can be used when the ACM Certificate must complain multiple domain names, from different hosted zones. For example, if you are using a CloudFront Distribution with multiple hosted zones.

Example: 
```yaml
zones = {
"<domain-name-1>" = "<hosted-zone-id-1>",
"<domain-name-2>" = "<hosted-zone-id-2>"
}
```

## :warning: Breaking changes
This upgrade **is not a breaking change**.