### PR TITLE
chore:push-ro-registry-terraform-restriction-erased

### DIFF
--- a/.github/workflows/push-to-registry.yml
+++ b/.github/workflows/push-to-registry.yml
@@ -25,4 +25,3 @@ jobs:
           version: ${{ github.ref_name }}
           path-to-zip: modules/
           lower-terraform-version: "0.99.99"
-          higher-terraform-version: "1.5.6"

--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -92,7 +92,7 @@ module "acm" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0, <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.5.0 |
 
 ## Providers


### PR DESCRIPTION
# 🚀 Release Notes

## 📌 Summary
<!-- Provide a brief summary of the changes introduced by this PR -->

---

## 🔧 Changes
<!-- List the main changes made in this PR -->
- [x] Feature added
- [ ] Bug fixed
- [ ] Documentation updated
- [ ] Other (please describe)

---

## 📖 Description
<!-- Add user-facing release notes here. These will be appended to the chart’s release notes -->

### ✨ New Features

-

### 🐛 Bug Fixes

-

### ⚠️ Breaking changes

-

### 📚 Documentation

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to remove the higher Terraform version input. Runs now rely solely on the lower version value, narrowing the Terraform version range used during execution.

* **Documentation**
  * Revised Terraform requirements to display only a minimum version (>= 1.0.0), removing the previous upper bound to reflect current support expectations and clarify setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->